### PR TITLE
add custom_stack_position etc for Julia (PyCall) support

### DIFF
--- a/pylustrator/QtGuiDrag.py
+++ b/pylustrator/QtGuiDrag.py
@@ -75,8 +75,8 @@ def initialize(use_global_variable_names=False):
     plt.figure = figure
     patchColormapsWithMetaInfo()
 
-    stack_call_position = traceback.extract_stack()[-2]
-    stack_call_position.filename
+    #stack_call_position = traceback.extract_stack()[-2]
+    #stack_call_position.filename
 
     plt.keys_for_lines = keys_for_lines
 
@@ -1123,3 +1123,4 @@ class PlotWindow(QtWidgets.QWidget):
                 event.ignore()
             if reply == QtWidgets.QMessageBox.Yes:
                 self.fig.change_tracker.save()
+                # app.clipboard().setText("\r\n".join(output))


### PR DESCRIPTION
I love the package but I normally use matplotlib from Julia. However, there are two problems:

1. `traceback.stack_position` gives the wrong file/line number if calling from Julia
2. The generated pylustrator code is in Python

I added a `custom_stack_position` so anything calling pylustrator from an unusual environment can manually declare the filename and lineno.

I also added `custom_prepend`, and `custom_append` variables so when we write to the Julia file we can wrap the generated code in a `py"""..."""` string, which tells Julia to run it as Python code.


Here is my Julia test file:

```julia
include("setup.jl")
pylustrator.start()
plt.figure()
plot([0,1],[0,1])
py"""#% start: automatic generated code from pylustrator
plt.figure(1).ax_dict = {ax.get_label(): ax for ax in plt.figure(1).axes}
import matplotlib as mpl
plt.figure(1).axes[0].set_position([0.376563, 0.439167, 0.523437, 0.438750])
#% end: automatic generated code from pylustrator"""
show()
```

The `setup.jl` is
```julia
using PyCall
using PyPlot
plt = pyimport("matplotlib.pyplot")
py"""
from matplotlib import pyplot as plt
"""

# ensure my local (modified) copy of pylustrator is loaded
pushfirst!(PyVector(pyimport("sys")."path"), "") 
pylustrator = pyimport("pylustrator")

function show()
    stack_pos = stacktrace()[2]
    filename = abspath(string(stack_pos.file))
    @assert filename == @__FILE__
    ct = pylustrator.change_tracker
    ct.custom_stack_position = ct.CustomStackPosition(filename,stack_pos.line)
    ct.custom_prepend = "py\"\"\""
    ct.custom_append = "\"\"\""
    plt.show()
end
```

If this was merged, I could make a small package for Julia that handles the install and wrapping of pylustrator, and maybe others could do the same for other languages