### PR TITLE
import pyplot as plt in generated code

### DIFF
--- a/pylustrator/change_tracker.py
+++ b/pylustrator/change_tracker.py
@@ -249,6 +249,7 @@ class ChangeTracker:
 
         fig = self.figure
         header = []
+        header += ["from matplotlib import pyplot as plt"]
         header += ["fig = plt.figure(%s)" % self.figure.number]
         header += ["import matplotlib as mpl"]
 


### PR DESCRIPTION
The automatically generated code assumes that pyplot is imported as `plt`, and will crash if it isn't.

I added `from matplotlib import pyplot as plt` into the generated code. I think this makes sense as `import matplotlib as mpl` is also there for eg `mpl.patches`.