### PR TITLE
Fixed errors that arrise because package was broken

### DIFF
--- a/pylustrator/QComplexWidgets.py
+++ b/pylustrator/QComplexWidgets.py
@@ -79,12 +79,15 @@ class TextPropertiesWidget(QtWidgets.QWidget):
 
         self.buttons_align = []
         self.align_names = ["left", "center", "right"]
+        align_group = QtWidgets.QButtonGroup(self)
         for align in self.align_names:
             button = QtWidgets.QPushButton(qta.icon("fa.align-" + align), "")
+            button.setToolTip("align "+align)
             button.setCheckable(True)
             button.clicked.connect(lambda x, name=align: self.changeAlign(name))
             self.layout.addWidget(button)
             self.buttons_align.append(button)
+            align_group.addButton(button)
 
         self.button_bold = QtWidgets.QPushButton(qta.icon("fa.bold"), "")
         self.button_bold.setCheckable(True)
@@ -111,6 +114,7 @@ class TextPropertiesWidget(QtWidgets.QWidget):
 
         self.button_delete = QtWidgets.QPushButton(qta.icon("fa.trash"), "")
         self.button_delete.clicked.connect(self.delete)
+        self.button_delete.setToolTip("delete")
         self.layout.addWidget(self.button_delete)
 
     def convertMplWeightToQtWeight(self, weight: str) -> int:
@@ -135,7 +139,7 @@ class TextPropertiesWidget(QtWidgets.QWidget):
         font0.setFamily(self.target.get_fontname())
         font0.setWeight(self.convertMplWeightToQtWeight(self.target.get_weight()))
         font0.setItalic(self.target.get_style() == "italic")
-        font0.setPointSizeF(self.target.get_fontsize())
+        font0.setPointSizeF(int(self.target.get_fontsize()))
         font, x = QtWidgets.QFontDialog.getFont(font0, self)
 
         for element in self.target_list:
@@ -170,7 +174,7 @@ class TextPropertiesWidget(QtWidgets.QWidget):
             else:
                 self.target_list = [element]
         self.target = None
-        self.font_size.setValue(element.get_fontsize())
+        self.font_size.setValue(int(element.get_fontsize()))
 
         index_selected = self.align_names.index(element.get_ha())
         for index, button in enumerate(self.buttons_align):
@@ -275,10 +279,12 @@ class TextPropertiesWidget2(QtWidgets.QWidget):
 
         self.buttons_align = []
         self.align_names = ["left", "center", "right"]
+        align_group = QtWidgets.QButtonGroup(self)
         for align in self.align_names:
             button = QtWidgets.QPushButton(qta.icon("fa.align-" + align), "")
             button.setCheckable(True)
             button.clicked.connect(lambda x, name=align: self.changeAlign(name))
+            align_group.addButton(button)
             self.layout.addWidget(button)
             self.buttons_align.append(button)
 
@@ -338,7 +344,7 @@ class TextPropertiesWidget2(QtWidgets.QWidget):
         font0.setFamily(self.target.get_fontname())
         font0.setWeight(self.convertMplWeightToQtWeight(self.target.get_weight()))
         font0.setItalic(self.target.get_style() == "italic")
-        font0.setPointSizeF(self.target.get_fontsize())
+        font0.setPointSizeF(int(self.target.get_fontsize()))
         font, x = QtWidgets.QFontDialog.getFont(font0, self)
 
         self.properties["fontname"] = font.family()
@@ -367,7 +373,7 @@ class TextPropertiesWidget2(QtWidgets.QWidget):
             else:
                 self.target_list = [element]
         self.target = None
-        self.font_size.setValue(element.get_fontsize())
+        self.font_size.setValue(int(element.get_fontsize()))
 
         index_selected = self.align_names.index(element.get_ha())
         for index, button in enumerate(self.buttons_align):
@@ -521,12 +527,15 @@ class LegendPropertiesWidget(QtWidgets.QWidget):
             elif name2 == "title":
                 value = element.get_title().get_text()
             elif name2 == "title_fontsize":
-                value = element.get_title().get_fontsize()
+                value = int(element.get_title().get_fontsize())
+            elif name2 == "_fontsize":
+                # matplotlib fontsizes are float, but Qt requires int
+                value = int(getattr(element, name2))
             else:
                 value = getattr(element, name2)
 
             try:
-                self.widgets[name].setValue(value)
+                self.widgets[name].setValue(int(value))
             except AttributeError:
                 self.widgets[name].set(value)
             self.properties[name] = value
@@ -1321,6 +1330,7 @@ class QItemProperties(QtWidgets.QWidget):
         self.fig.change_tracker.addChange(self.element, ".legend()")
         self.fig.figure_dragger.make_dragable(self.element.get_legend())
         self.fig.canvas.draw()
+        self.tree.updateEntry(self.element, update_children=True)
 
     def changePickable(self):
         """ make the target pickable """

--- a/pylustrator/QComplexWidgets.py
+++ b/pylustrator/QComplexWidgets.py
@@ -535,7 +535,7 @@ class LegendPropertiesWidget(QtWidgets.QWidget):
                 value = getattr(element, name2)
 
             try:
-                self.widgets[name].setValue(int(value))
+                self.widgets[name].setValue(value)
             except AttributeError:
                 self.widgets[name].set(value)
             self.properties[name] = value

--- a/pylustrator/QLinkableWidgets.py
+++ b/pylustrator/QLinkableWidgets.py
@@ -673,7 +673,7 @@ class QColorWidget(QtWidgets.QWidget, Linkable):
     def OpenDialog(self):
         """ open a color chooser dialog """
         # get new color from color picker
-        self.current_color = QtGui.QColor(*tuple(mpl.colors.to_rgba_array(self.getColor())[0] * 255))
+        self.current_color = QtGui.QColor(*tuple(int(x) for x in mpl.colors.to_rgba_array(self.getColor())[0] * 255))
         self.dialog = QtWidgets.QColorDialog(self.current_color, self.parent())
         self.dialog.setOptions(QtWidgets.QColorDialog.ShowAlphaChannel)
         for index, color in enumerate(plt.rcParams['axes.prop_cycle'].by_key()['color']):

--- a/pylustrator/QtGui.py
+++ b/pylustrator/QtGui.py
@@ -49,7 +49,7 @@ def my_excepthook(type, value, tback):
 
 sys.excepthook = my_excepthook
 
-""" Matplotlib overlaod """
+""" Matplotlib overload """
 figures = {}
 app = None
 

--- a/pylustrator/QtGuiDrag.py
+++ b/pylustrator/QtGuiDrag.py
@@ -482,7 +482,6 @@ class MyTreeView(QtWidgets.QTreeView):
         if item is None:
             # get the parent entry
             parent_entry = self.getParentEntry(entry)
-            parent_item = None
             # if we have a parent and are not at the top level try to get the corresponding item
             if parent_entry:
                 parent_item = self.getItemFromEntry(parent_entry)
@@ -491,6 +490,8 @@ class MyTreeView(QtWidgets.QTreeView):
                     if parent_item:
                         parent_item.setText(self.getNameOfEntry(parent_entry))
                     return
+            else:
+                parent_item = None
 
             # define the row where the new item should be
             row = None
@@ -544,6 +545,7 @@ class MyTreeView(QtWidgets.QTreeView):
 
     def deleteEntry(self, entry: Artist):
         """ delete an entry from the tree """
+        # get the tree view item for the database entry
         item = self.getItemFromEntry(entry)
         if item is None:
             return
@@ -555,11 +557,13 @@ class MyTreeView(QtWidgets.QTreeView):
         key = self.getKey(entry)
         del self.item_lookup[key]
 
+        # delete row from the treeview
         if parent_item is None:
             self.model.removeRow(item.row())
         else:
-            item.parent().removeRow(item.row())
+            item.parent().removeRow(item.row(), item.parent())
 
+        # update the label of parent item
         if parent_item:
             name = self.getNameOfEntry(parent_entry)
             if name is not None:
@@ -623,12 +627,15 @@ class Align(QtWidgets.QWidget):
         icons = ["left_x.png", "center_x.png", "right_x.png", "distribute_x.png", "top_y.png", "center_y.png",
                  "bottom_y.png", "distribute_y.png", "group.png"]
         self.buttons = []
+        align_group = QtWidgets.QButtonGroup(self)
         for index, act in enumerate(actions):
             button = QtWidgets.QPushButton(QtGui.QIcon(os.path.join(os.path.dirname(__file__), "icons", icons[index])),
                                            "")
+            button.setToolTip(act.replace('_', ' '))
             self.layout.addWidget(button)
             button.clicked.connect(lambda x, act=act: self.execute_action(act))
             self.buttons.append(button)
+            align_group.addButton(button)
             if index == 3:
                 line = QtWidgets.QFrame()
                 line.setFrameShape(QtWidgets.QFrame.VLine)
@@ -753,7 +760,7 @@ class PlotWindow(QtWidgets.QWidget):
         def updateChangesSignal(undo, redo, undo_text, redo_text):
             button_undo.setDisabled(undo)
             undoAct.setDisabled(undo)
-            if undo_text is not "":
+            if undo_text != "":
                 undoAct.setText(f"Undo: {undo_text}")
                 button_undo.setToolTip(f"Undo: {undo_text}")
             else:
@@ -761,7 +768,7 @@ class PlotWindow(QtWidgets.QWidget):
                 button_undo.setToolTip(f"Undo")
             button_redo.setDisabled(redo)
             redoAct.setDisabled(redo)
-            if redo_text is not "":
+            if redo_text != "":
                 redoAct.setText(f"Redo: {redo_text}")
                 button_redo.setToolTip(f"Redo: {redo_text}")
             else:
@@ -923,16 +930,16 @@ class PlotWindow(QtWidgets.QWidget):
         for i, pos_cm in enumerate(np.arange(start_x, end_x, dx)):
             x = (trans.transform((pos_cm, 0))[0] + offset)
             if i % 10 == 0:
-                painterX.drawLine(x, l - l1 - 1, x, l - 1)
+                painterX.drawLine(int(x), int(l - l1 - 1), int(x), int(l - 1))
                 text = str("%d" % np.round(pos_cm))
                 o = 0
-                painterX.drawText(x + 3, o, self.fontMetrics().width(text), o + self.fontMetrics().height(),
+                painterX.drawText(int(x + 3), int(o), int(self.fontMetrics().width(text)), int(o + self.fontMetrics().height()),
                                   QtCore.Qt.AlignLeft,
                                   text)
             elif i % 2 == 0:
-                painterX.drawLine(x, l - l2 - 1, x, l - 1)
+                painterX.drawLine(int(x), int(l - l2 - 1), int(x), int(l - 1))
             else:
-                painterX.drawLine(x, l - l3 - 1, x, l - 1)
+                painterX.drawLine(int(x), int(l - l3 - 1), int(x), int(l - 1))
         painterX.drawLine(0, l - 2, w, l - 2)
         painterX.setPen(QtGui.QPen(QtGui.QColor("white"), 1))
         painterX.drawLine(0, l - 1, w, l - 1)
@@ -947,22 +954,22 @@ class PlotWindow(QtWidgets.QWidget):
         for i, pos_cm in enumerate(np.arange(start_y, end_y, dy)):
             y = (-trans.transform((0, pos_cm))[1] + offset)
             if i % 10 == 0:
-                painterY.drawLine(l - l1 - 1, y, l - 1, y)
+                painterY.drawLine(int(l - l1 - 1), int(y), int(l - 1), int(y))
                 text = str("%d" % np.round(pos_cm))
                 o = 0
-                painterY.drawText(o, y + 3, o + self.fontMetrics().width(text), self.fontMetrics().height(),
+                painterY.drawText(int(o), int(y + 3), int(o + self.fontMetrics().width(text)), int(self.fontMetrics().height()),
                                   QtCore.Qt.AlignRight,
                                   text)
             elif i % 2 == 0:
-                painterY.drawLine(l - l2 - 1, y, l - 1, y)
+                painterY.drawLine(int(l - l2 - 1), int(y), int(l - 1), int(y))
             else:
-                painterY.drawLine(l - l3 - 1, y, l - 1, y)
-        painterY.drawLine(l - 2, 0, l - 2, h)
+                painterY.drawLine(int(l - l3 - 1), int(y), int(l - 1), int(y))
+        painterY.drawLine(int(l - 2), 0, int(l - 2), int(h))
         painterY.setPen(QtGui.QPen(QtGui.QColor("white"), 1))
-        painterY.drawLine(l - 1, 0, l - 1, h)
+        painterY.drawLine(int(l - 1), 0, int(l - 1), int(h))
         painterY.setPen(QtGui.QPen(QtGui.QColor("#f0f0f0"), 0))
         painterY.setBrush(QtGui.QBrush(QtGui.QColor("#f0f0f0")))
-        painterY.drawRect(0, 0, l, l)
+        painterY.drawRect(0, 0, int(l), int(l))
         self.y_scale.setPixmap(self.pixmapY)
         self.y_scale.setMinimumSize(l, h)
         self.y_scale.setMaximumSize(l, h)
@@ -1038,7 +1045,7 @@ class PlotWindow(QtWidgets.QWidget):
     def moveCanvasCanvas(self, offset_x: float, offset_y: float):
         """ when the canvas is panned """
         p = self.canvas_container.pos()
-        self.canvas_container.move(p.x() + offset_x, p.y() + offset_y)
+        self.canvas_container.move(int(p.x() + offset_x), int(p.y() + offset_y))
 
         self.updateRuler()
 
@@ -1072,8 +1079,8 @@ class PlotWindow(QtWidgets.QWidget):
             self.canvas_container.setMinimumSize(w, h)
             self.canvas_container.setMaximumSize(w, h)
 
-            self.canvas_container.move((self.canvas_canvas.width() - w) / 2 + 5,
-                                       (self.canvas_canvas.height() - h) / 2 + 5)
+            self.canvas_container.move(int((self.canvas_canvas.width() - w) / 2 + 5),
+                                       int((self.canvas_canvas.height() - h) / 2 + 5))
 
             self.updateRuler()
             self.fig.canvas.draw()
@@ -1083,8 +1090,8 @@ class PlotWindow(QtWidgets.QWidget):
             self.canvas_canvas.setMinimumWidth(w + 30)
             self.canvas_canvas.setMinimumHeight(h + 30)
 
-            self.canvas_container.move((self.canvas_canvas.width() - w) / 2 + 5,
-                                       (self.canvas_canvas.height() - h) / 2 + 5)
+            self.canvas_container.move(int((self.canvas_canvas.width() - w) / 2 + 5),
+                                       int((self.canvas_canvas.height() - h) / 2 + 5))
             self.updateRuler()
 
     def keyReleaseEvent(self, event: QtCore.QEvent):


### PR DESCRIPTION
## summary of changes on a per-file basis

- pylustrator/QComplexWidgets.py
  1. made a `QButtonGroup` which makes the align buttons exclusive (you can't have 2 aligns checked at the same time)
  2. added tooltip for trash
  3. added `int` to some places where it was needed
- pylustrator/QLinkableWidgets.py
  1. added `int` where needed
- pylustrator/QtGui.py
  1. spelling mistake
- pylustrator/QtGuiDrag.py
  1. use else instead of default value for better readability
  2. added comment
  3. used `int` where needed
  4. replaced `is not` with `!=`

## remarks
- maybe it is a nice time to update the version of the program
- this still uses `requirements.txt`, I think it would be nice to 'upgrade' to a `pyproject.toml` [see here](https://packaging.python.org/en/latest/tutorials/packaging-projects/). I could do it but I don't want to force people into using a different system.
- the version on pypi is outdated. I want to recomment this package to students that are less tech savy and it would be nice if they could just use pip to install the newer version on this. Could you please update it?
- it could be the case that I used `int` where it wasn't strictly needed

## this fixes
#45